### PR TITLE
fix: typo in clear all function

### DIFF
--- a/src/pages/Codet.jsx
+++ b/src/pages/Codet.jsx
@@ -229,11 +229,7 @@ export default function Codet() {
 
   const handleClearAll = () => {
     if (confirm("Are you sure you want to clear all code?")) {
-      setHtml(`<html>
-<body>  
-</body>
-</html>
-        `);
+      setHtml("");
       setCss("");
       setJs("");
     }


### PR DESCRIPTION
simplify clear all functionality by resetting HTML to an empty string.